### PR TITLE
fix: restrict release trigger to semver tags only

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -2,7 +2,7 @@ name: 'Release'
 
 on:
   push:
-    tags: ['*']
+    tags: ['[0-9]+.[0-9]+.[0-9]+']
 
 permissions:
   contents: 'write'


### PR DESCRIPTION
## Type

<!-- Select one: feat | fix | refactor | docs | test | chore | perf | ci -->

## Related Issue

<!-- #123 or N/A -->

## Summary

<!-- What changed and why -->

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here -->
N/A

## Checklist

- [ ] Tests pass locally
- [ ] Code follows project conventions
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented above)
- [ ] PR title follows conventional commits format (`type(scope): description`)
