### PR TITLE
feat(ci): bump ci-workflows to @v4

### DIFF
--- a/.github/workflows/build-on-branch.yml
+++ b/.github/workflows/build-on-branch.yml
@@ -10,9 +10,9 @@ permissions:
 
 jobs:
   check:
-    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-check.yml@v3
+    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-check.yml@v4
     with:
       java-version: '17'
 
   label:
-    uses: zenhelix/ci-workflows/.github/workflows/labeler.yml@v3
+    uses: zenhelix/ci-workflows/.github/workflows/labeler.yml@v4

--- a/.github/workflows/build-on-main.yml
+++ b/.github/workflows/build-on-main.yml
@@ -9,13 +9,13 @@ permissions:
 
 jobs:
   check:
-    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-check.yml@v3
+    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-check.yml@v4
     with:
       java-version: '17'
 
   create-tag:
     needs: check
-    uses: zenhelix/ci-workflows/.github/workflows/gradle-create-tag.yml@v3
+    uses: zenhelix/ci-workflows/.github/workflows/gradle-create-tag.yml@v4
     with:
       java-version: '17'
     secrets: inherit

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   analyze:
-    uses: zenhelix/ci-workflows/.github/workflows/codeql-analysis.yml@v3
+    uses: zenhelix/ci-workflows/.github/workflows/codeql-analysis.yml@v4

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-release.yml@v3
+    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-release.yml@v4
     with:
       java-version: '17'
       publish-command: './gradlew publishPlugins publish -Pversion=''${{ github.ref_name }}'''


### PR DESCRIPTION
## Summary

Bumps `zenhelix/ci-workflows` reusable-workflow refs from `@v3` to `@v4` (or `@v2`→`@v4` for older consumers). Part of Spec 6 rollout — third-party actions inside ci-workflows are now SHA-pinned; reusable-workflow refs in this PR stay as tags because GitHub's `sha_pinning_required` policy exempts them.

Spec: `zenhelix/infra/docs/superpowers/specs/2026-04-20-spec6-ci-workflows-sha-pinning-design.md`.

## Test plan

- [ ] PR CI is green (existing build workflow resolves ci-workflows@v4 and passes)