### PR TITLE
chore: bump ci-workflows to v5

### DIFF
--- a/.github/workflows/build-on-branch.yml
+++ b/.github/workflows/build-on-branch.yml
@@ -10,9 +10,9 @@ permissions:
 
 jobs:
   check:
-    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-check.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-check.yml@v5
     with:
       java-version: '17'
 
   label:
-    uses: zenhelix/ci-workflows/.github/workflows/labeler.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/labeler.yml@v5

--- a/.github/workflows/build-on-main.yml
+++ b/.github/workflows/build-on-main.yml
@@ -9,13 +9,13 @@ permissions:
 
 jobs:
   check:
-    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-check.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-check.yml@v5
     with:
       java-version: '17'
 
   create-tag:
     needs: check
-    uses: zenhelix/ci-workflows/.github/workflows/gradle-create-tag.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/gradle-create-tag.yml@v5
     with:
       java-version: '17'
     secrets: inherit

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   analyze:
-    uses: zenhelix/ci-workflows/.github/workflows/codeql-analysis.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/codeql-analysis.yml@v5

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-release.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-release.yml@v5
     with:
       java-version: '17'
       publish-command: './gradlew publishPlugins publish -Pversion=''${{ github.ref_name }}'''


### PR DESCRIPTION
## Summary
Pilot bump per Spec 13 Phase 1.5. Validates v5 fixes for bugs #1, #1b, #2 on a single repo before bulk-bumping the other 8 Kotlin/Java consumers.

Changes:
- `.github/workflows/build-on-branch.yml`: 2× `@v4` → `@v5`
- `.github/workflows/build-on-main.yml`: 2× `@v4` → `@v5`
- `.github/workflows/codeql-analysis.yml`: 1× `@v4` → `@v5`
- `.github/workflows/release-on-tag.yml`: 1× `@v4` → `@v5`

## Test plan
- [ ] Verify Workflows passes on PR (if applicable)
- [ ] After merge: Build & Tag turns green on next push to main (was failing exit 127 due to missing checkout in v4 check.yml)
- [ ] After merge: CodeQL turns green on next push to main (was failing configuration_error due to empty database in v4 codeql-analysis.yml)

Spec: https://github.com/zenhelix/infra/blob/spec13/infra-pipeline-stabilization/docs/superpowers/specs/2026-04-26-spec13-infra-pipeline-stabilization-design.md